### PR TITLE
Add Indices To Lists

### DIFF
--- a/lib/uri_query.ex
+++ b/lib/uri_query.ex
@@ -17,7 +17,7 @@ defmodule UriQuery do
 
   iex> query = %{foo: ["bar", "baz"]}
   iex> UriQuery.params(query)
-  [{"foo[]", "bar"}, {"foo[]", "baz"}]
+  [{"foo[0]", "bar"}, {"foo[1]", "baz"}]
 
   iex> query = %{"user" => %{"name" => "John Doe", "email" => "test@example.com"}}
   iex> UriQuery.params(query)
@@ -41,9 +41,16 @@ defmodule UriQuery do
     Enum.reduce(values, acc, fn (value, acc) -> accumulate_kv_pair(prefix, {key, value}, true, acc) end)
   end
   defp accumulate_kv_pair(prefix, {key, values}, _, acc) when is_list(values) do
-    values
-    |> Enum.with_index
-    |> Enum.map(fn {value, index} -> {index, value} end)
+    tuples =
+      if Keyword.keyword?(values) do
+        values
+      else
+        values
+        |> Enum.with_index
+        |> Enum.map(fn {value, index} -> {index, value} end)
+      end
+
+    tuples
     |> Enum.reduce(acc, fn (value, acc) -> accumulate_kv_pair(prefix, {key, value}, true, acc) end)
   end
   defp accumulate_kv_pair(prefix, {key, {nested_key, value}}, _, acc) do

--- a/lib/uri_query.ex
+++ b/lib/uri_query.ex
@@ -37,8 +37,14 @@ defmodule UriQuery do
   defp accumulate_kv_pair(_, {key, _}, _, _) when is_list(key) do
     raise ArgumentError, "params/1 keys cannot be lists, got: #{inspect key}"
   end
-  defp accumulate_kv_pair(prefix, {key, values}, _, acc) when is_list(values) or is_map(values) do
+  defp accumulate_kv_pair(prefix, {key, values}, _, acc) when is_map(values) do
     Enum.reduce(values, acc, fn (value, acc) -> accumulate_kv_pair(prefix, {key, value}, true, acc) end)
+  end
+  defp accumulate_kv_pair(prefix, {key, values}, _, acc) when is_list(values) do
+    values
+    |> Enum.with_index
+    |> Enum.map(fn {value, index} -> {index, value} end)
+    |> Enum.reduce(acc, fn (value, acc) -> accumulate_kv_pair(prefix, {key, value}, true, acc) end)
   end
   defp accumulate_kv_pair(prefix, {key, {nested_key, value}}, _, acc) do
     build_key(prefix, key)

--- a/test/uri_encode_query_test.exs
+++ b/test/uri_encode_query_test.exs
@@ -10,7 +10,7 @@ defmodule UriEncodeQueryTest do
   end
 
   test "list value" do
-    assert UriQuery.params(foo: ["bar", "quux"]) |> URI.encode_query == "foo%5B%5D=bar&foo%5B%5D=quux"
+    assert UriQuery.params(foo: ["bar", "quux"]) |> URI.encode_query == "foo%5B0%5D=bar&foo%5B1%5D=quux"
   end
 
   test "nested tupple" do
@@ -30,21 +30,19 @@ defmodule UriEncodeQueryTest do
   end
 
   test "complex cases" do
-    assert UriQuery.params([{:foo, [{:bar, ["baz", "quux"]}, {:quux, :corge}]}, {:grault, :garply}]) |> URI.encode_query == "foo%5Bbar%5D%5B%5D=baz&foo%5Bbar%5D%5B%5D=quux&foo%5Bquux%5D=corge&grault=garply"
-    assert UriQuery.params([{:foo, {:bar, ["baz", "qux"]}}]) |> URI.encode_query == "foo%5Bbar%5D%5B%5D=baz&foo%5Bbar%5D%5B%5D=qux"
+    assert UriQuery.params([{:foo, [{:bar, ["baz", "quux"]}, {:quux, :corge}]}, {:grault, :garply}]) |> URI.encode_query == "foo%5Bbar%5D%5B0%5D=baz&foo%5Bbar%5D%5B1%5D=quux&foo%5Bquux%5D=corge&grault=garply"
+    assert UriQuery.params([{:foo, {:bar, ["baz", "qux"]}}]) |> URI.encode_query == "foo%5Bbar%5D%5B0%5D=baz&foo%5Bbar%5D%5B1%5D=qux"
   end
 
   test "with map" do
     assert UriQuery.params(%{user: %{name: "Dougal McGuire", email: "test@example.com"}}) |> URI.encode_query == "user%5Bemail%5D=test%40example.com&user%5Bname%5D=Dougal+McGuire"
     assert UriQuery.params(%{user: %{name: "Dougal McGuire", meta: %{foo: "bar", baz: "qux"}}}) |> URI.encode_query == "user%5Bmeta%5D%5Bbaz%5D=qux&user%5Bmeta%5D%5Bfoo%5D=bar&user%5Bname%5D=Dougal+McGuire"
-    assert UriQuery.params(%{user: %{name: "Dougal McGuire", meta: %{test: "Example", data: ["foo", "bar"]}}}) |> URI.encode_query == "user%5Bmeta%5D%5Bdata%5D%5B%5D=foo&user%5Bmeta%5D%5Bdata%5D%5B%5D=bar&user%5Bmeta%5D%5Btest%5D=Example&user%5Bname%5D=Dougal+McGuire"
+    assert UriQuery.params(%{user: %{name: "Dougal McGuire", meta: %{test: "Example", data: ["foo", "bar"]}}}) |> URI.encode_query == "user%5Bmeta%5D%5Bdata%5D%5B0%5D=foo&user%5Bmeta%5D%5Bdata%5D%5B1%5D=bar&user%5Bmeta%5D%5Btest%5D=Example&user%5Bname%5D=Dougal+McGuire"
   end
 
   test "ignores empty list" do
     assert UriQuery.params(foo: []) |> URI.encode_query == ""
     assert UriQuery.params(foo: [], bar: "quux") |> URI.encode_query == "bar=quux"
-    assert UriQuery.params(foo: [], bar: ["quux", []]) |> URI.encode_query == "bar%5B%5D=quux"
+    assert UriQuery.params(foo: [], bar: ["quux", []]) |> URI.encode_query == "bar%5B0%5D=quux"
   end
 end
-
-

--- a/test/uri_query_test.exs
+++ b/test/uri_query_test.exs
@@ -29,7 +29,7 @@ defmodule UriQueryTest do
   end
 
   test "list value" do
-    assert UriQuery.params(foo: ["bar", "quux"]) == [{"foo[]", "bar"}, {"foo[]", "quux"}]
+    assert UriQuery.params(foo: ["bar", "quux"]) == [{"foo[0]", "bar"}, {"foo[1]", "quux"}]
   end
 
   test "nested tupple" do
@@ -49,19 +49,19 @@ defmodule UriQueryTest do
   end
 
   test "complex cases" do
-    assert UriQuery.params([{:foo, [{:bar, ["baz", "quux"]}, {:quux, :corge}]}, {:grault, :garply}]) == [{"foo[bar][]", "baz"}, {"foo[bar][]", "quux"}, {"foo[quux]", "corge"}, {"grault", "garply"}]
-    assert UriQuery.params([{:foo, {:bar, ["baz", "qux"]}}]) == [{"foo[bar][]", "baz"}, {"foo[bar][]", "qux"}]
+    assert UriQuery.params([{:foo, [{:bar, ["baz", "quux"]}, {:quux, :corge}]}, {:grault, :garply}]) == [{"foo[bar][0]", "baz"}, {"foo[bar][1]", "quux"}, {"foo[quux]", "corge"}, {"grault", "garply"}]
+    assert UriQuery.params([{:foo, {:bar, ["baz", "qux"]}}]) == [{"foo[bar][0]", "baz"}, {"foo[bar][1]", "qux"}]
   end
 
   test "with map" do
     assert UriQuery.params(%{user: %{name: "Dougal McGuire", email: "test@example.com"}}) == [{"user[email]", "test@example.com"}, {"user[name]", "Dougal McGuire"}]
     assert UriQuery.params(%{user: %{name: "Dougal McGuire", meta: %{foo: "bar", baz: "qux"}}}) == [{"user[meta][baz]", "qux"}, {"user[meta][foo]", "bar"}, {"user[name]", "Dougal McGuire"}]
-    assert UriQuery.params(%{user: %{name: "Dougal McGuire", meta: %{test: "Example", data: ["foo", "bar"]}}}) == [{"user[meta][data][]", "foo"}, {"user[meta][data][]", "bar"}, {"user[meta][test]", "Example"}, {"user[name]", "Dougal McGuire"}]
+    assert UriQuery.params(%{user: %{name: "Dougal McGuire", meta: %{test: "Example", data: ["foo", "bar"]}}}) == [{"user[meta][data][0]", "foo"}, {"user[meta][data][1]", "bar"}, {"user[meta][test]", "Example"}, {"user[name]", "Dougal McGuire"}]
   end
 
   test "ignores empty list" do
     assert UriQuery.params(foo: []) == []
     assert UriQuery.params(foo: [], bar: "quux") == [{"bar", "quux"}]
-    assert UriQuery.params(foo: [], bar: ["quux", []]) == [{"bar[]", "quux"}]
+    assert UriQuery.params(foo: [], bar: ["quux", []]) == [{"bar[0]", "quux"}]
   end
 end


### PR DESCRIPTION
For lists that do not otherwise have keys (aka lists that aren't keyword lists), adds indices to the payload. Otherwise keeps current implementation.

```
%{a: %{b: [:c, :d]}} --> a[b][0]=c&a[b][1]=d
```