### PR TITLE
Fix various Elixir 15/OTP 26 errors and warnings...

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/uri_query.ex
+++ b/lib/uri_query.ex
@@ -37,7 +37,7 @@ defmodule UriQuery do
     |> Enum.reduce([], fn(pair, acc) -> accumulate_kv_pair("", pair, false, acc, opts) end)
     |> Enum.reverse
   end
-  def params(_, _), do: raise ArgumentError, @noKVListError
+  def params(_, _), do: raise(ArgumentError, @noKVListError)
 
   defp accumulate_kv_pair(_, {key, _}, _, _, _) when is_list(key) do
     raise ArgumentError, "params/1 keys cannot be lists, got: #{inspect key}"
@@ -71,7 +71,7 @@ defmodule UriQuery do
   defp accumulate_kv_pair(prefix, {key, value}, _false, acc, _opts) do
     [{build_key(prefix, key), to_string(value)} | acc]
   end
-  defp accumulate_kv_pair(_, _, _, _, _), do: raise ArgumentError, @noKVListError
+  defp accumulate_kv_pair(_, _, _, _, _), do: raise(ArgumentError, @noKVListError)
 
   defp build_key(prefix, key)        , do: prefix <> to_string(key)
   defp build_key(prefix, key, suffix), do: prefix <> to_string(key) <> suffix

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule UriQuery.Mixfile do
   def project do
     [app: :uri_query,
      version: "0.1.2",
-     elixir: "~> 1.3",
+     elixir: "~> 1.9",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps(),

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,4 @@
-%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.1", "bfed8d4e93c755e2b150be925ad2cfa6af7c3bfcacc3b609f45f6048c9d623d6", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+%{
+  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], [], "hexpm", "db7b13d74a9edc54d3681762154d164d4a661cd27673cca80760344449877664"},
+  "ex_doc": {:hex, :ex_doc, "0.14.1", "bfed8d4e93c755e2b150be925ad2cfa6af7c3bfcacc3b609f45f6048c9d623d6", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "492e576a7559c13e63944b8f22ae0299bca801cf6555e0df17a61e923b1b42af"},
+}


### PR DESCRIPTION


Hi @shhavel ,

I came across a couple of benign warnings about brackets on this transitive dependency, and it turned out to be a slightly longer than usual yak shave.  Seems the tests broke due to changes in OTP 26 and Elixir 1.14.  I fixed those along with the parentheses.  Tested against both latest and prior OTP.

Hope this is useful to you and other people and makes it upstream.

Cheers,

Jarrod

```
- Add brackets to function invocations after `do:` to avoid ambiguity (OTP 26 warning)
- Fix broken tests around undefined map order in OTP 26
- Avoid using charlists to test list exception as Elixir inspect now formats this as ~s"..." as of v1.14.0
- `import Config` instead of `use Mix.Config`

Test pass against:
Elixir 1.15.6
OTP 25.3.2.6
OTP 26.1
```